### PR TITLE
Updates to example analysis in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ iguide setup configs/simulation.config.yml
 
 iguide run configs/simulation.config.yml -- -np
 iguide run configs/simulation.config.yml -- --latency-wait 30
-cat analysis/simulation/output/unique_sites.simulation.csv
+zcat analysis/simulation/output/unique_sites.simulation.csv.gz
 
 # Processing will complete with a report, but if additional analyses are required,
 # you can reevaluate the 'incorp_sites' object. Multiple objects can be evaluated

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ zcat analysis/simulation/output/unique_sites.simulation.csv.gz
 # you can reevaluate the 'incorp_sites' object. Multiple objects can be evaluated
 # together, just include the run files.
 
-iguide eval analysis/simulation/output/incorp_sites.simulation.rds \
+iguide eval analysis/simulation/config.yml \
   -o analysis/simulation/output/iguide.eval.simulation.test.rds \
   -s sampleInfo/simulation.supp.csv
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ conda activate iguide
 iguide list_samples configs/simulation.config.yml
 
 # Create test analysis directory
-# (The simulation configuration file is used by default and does not need to be specified)
 
 iguide setup configs/simulation.config.yml
 


### PR DESCRIPTION
This proposes a few updates to the README to match the latest iGUIDE behavior I saw when running through the example analysis.

 * Without specifying a config file path for `iguide setup` I get `setup: error: the following arguments are required: CONFIG_FILE` but it works as written in the example (so I took out the bit about not needing the configuration file argument)
 * The rule `compress_unique_sites` implicitly removes the plaintext version, so I updated the filename in the README to match and switched to zcat instead of cat.
 * The `iguide eval` command gives me an error (""invalid input found on input connection") and I saw that the help text says a conf file path should be given first.  I updated the example command to give the simulation config file instead of the original RDS file.  (But double-check me on this one!)

If this is right it might need updating in readthedocs too.  Everything else ran smoothly all the way through to HTML and PDF report files.  Thanks Chris!