### PR TITLE
Allow readNamePattern via config for demulti and filt rules

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -108,6 +108,11 @@ rule all:
       summary=RUN_DIR + "/reports/summary." + RUN + ".txt",
       stats=RUN_DIR + "/reports/runstats." + RUN + ".html"
 
+def read_name_pattern_arg(wildcards):
+    """Optional read name pattern argument from config for R scripts."""
+    p = config.get("readNamePattern")
+    return '--readNamePattern "%s"' % p if p else ""
+
 # Architecture Rules
 include: "rules/arch.rules"
 

--- a/rules/demulti.rules
+++ b/rules/demulti.rules
@@ -45,7 +45,7 @@ rule demultiplex:
   shell:
     """
     Rscript {params.tool} -m {ROOT_DIR}/{input.sampleInfo} \
-      {readNamePatternArg} \
+      {params.readNamePatternArg} \
       --read1 {input.R1} --read2 {input.R2} \
       --idx1 {input.I1} --idx2 {input.I2} \
       --bc1 {params.bc1} --bc1Len {params.bc1Len} \

--- a/rules/demulti.rules
+++ b/rules/demulti.rules
@@ -1,6 +1,11 @@
 # -*- mode: Snakemake -*-
 # Demultiplexing Rules
 
+def read_name_pattern_arg(wildcards):
+    """Optional read name pattern argument from config for demulti.R"""
+    p = config.get("readNamePattern")
+    return '--readNamePattern "%s"' % p if p else ""
+
 rule demultiplex:
   input:
     configFile=ancient("configs/" + RUN + ".config.yml"),
@@ -22,6 +27,7 @@ rule demultiplex:
     stat=temp(RUN_DIR + "/process_data/" + RUN + ".demulti.stat")
   params:
     tool=ROOT_DIR + "/tools/rscripts/demulti.R",
+    readNamePatternArg=read_name_pattern_arg,
     bc1Len=config["barcode1Length"],
     bc2Len=config["barcode2Length"],
     bc1=config["barcode1"],
@@ -39,6 +45,7 @@ rule demultiplex:
   shell:
     """
     Rscript {params.tool} -m {ROOT_DIR}/{input.sampleInfo} \
+      {readNamePatternArg} \
       --read1 {input.R1} --read2 {input.R2} \
       --idx1 {input.I1} --idx2 {input.I2} \
       --bc1 {params.bc1} --bc1Len {params.bc1Len} \

--- a/rules/demulti.rules
+++ b/rules/demulti.rules
@@ -1,11 +1,6 @@
 # -*- mode: Snakemake -*-
 # Demultiplexing Rules
 
-def read_name_pattern_arg(wildcards):
-    """Optional read name pattern argument from config for demulti.R"""
-    p = config.get("readNamePattern")
-    return '--readNamePattern "%s"' % p if p else ""
-
 rule demultiplex:
   input:
     configFile=ancient("configs/" + RUN + ".config.yml"),

--- a/rules/filt.rules
+++ b/rules/filt.rules
@@ -10,7 +10,8 @@ rule seq_filter:
     R2=temp(RUN_DIR + "/process_data/{sample}.R2.filt.fastq.gz"),
     stat=temp(RUN_DIR + "/process_data/{sample}.filt.stat")
   params:
-    tool=ROOT_DIR + "/tools/rscripts/filt.R"
+    tool=ROOT_DIR + "/tools/rscripts/filt.R",
+    readNamePatternArg=read_name_pattern_arg
   log:
     RUN_DIR + "/logs/{sample}.filt.log"
   resources:
@@ -18,5 +19,6 @@ rule seq_filter:
   shell:
     """
     Rscript {params.tool} {input.R1} {input.R2} -o {output.R1} {output.R2} \
+      {params.readNamePatternArg} \
       --stat {output.stat} --compress > {log} 2>&1
     """


### PR DESCRIPTION
This supplies a custom readNamePattern for the demulti and filt rules via the configuration, if one is present.  (If not, that argument is left out of the command line strings so nothing changes.)  I'm using this change to process reads that have the SRA's weird naming.  Fixes #43.