### PR TITLE
Optional UMItags

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -117,6 +117,8 @@ include: "rules/trim.rules"
 if (config["UMItags"]):
     include: "rules/umitag.rules"
     UMIseqs = sampleInfo["barcode2"]
+else:
+    include: "rules/umitag_stub.rules"
 include: "rules/filt.rules"
 include: "rules/consol.rules"
 if (config["Aligner"] == "BLAT" or config["Aligner"] == "blat"):

--- a/rules/umitag_stub.rules
+++ b/rules/umitag_stub.rules
@@ -1,0 +1,7 @@
+# -*- mode: Snakemake -*-
+# Sequence Collecting Rules
+
+rule collect_umitags_stub:
+  output:
+    stat=temp(RUN_DIR + "/process_data/{sample}.umitags.stat")
+  shell: "touch {output.stat}"

--- a/tools/rscripts/generate_stat_report.R
+++ b/tools/rscripts/generate_stat_report.R
@@ -157,10 +157,10 @@ sampleName_levels <- c(
 
 # Read attrition table ----
 read_tbl <- dplyr::select(
-    stat_df, sampleName, demulti.reads, R1.trim.reads, R2.primer.trim.reads, 
-    R2.trim.reads, umitags.reads, filt.reads, R1.consol.reads, R2.consol.reads, 
+    stat_df, c(sampleName, demulti.reads, R1.trim.reads, R2.primer.trim.reads,
+    R2.trim.reads, if (config$UMItags) umitags.reads, filt.reads, R1.consol.reads, R2.consol.reads,
     align.unique.reads, align.chimera.reads, align.multihit.reads
-  ) %>%
+  )) %>%
   dplyr::mutate(sampleName = factor(sampleName, levels = sampleName_levels)) %>%
   dplyr::arrange(sampleName)
 


### PR DESCRIPTION
For cases where UMItags are disabled in the config, this changes the rule includes to supply empty umitag .stat files for downstream processing, and conditionally excludes the umitags.reads column in the Read attrition table.  Fixes #42.